### PR TITLE
Make sure the end user isn't setting the options/hostname attrib.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rarodriguez@mdsol.com'
 license          'Apache 2.0'
 description      'Installs/Configures Marathon'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.1'
+version          '1.0.2'
 
 %w{ ubuntu }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -128,10 +128,13 @@ else
   end
 end
 
-if node.attribute?('ec2')
-  hostname = "--hostname #{node['ec2']['public_hostname']}"
-else
-  hostname = "--hostname #{node['ipaddress']}"
+# Don't add duplicate hostname flags if the attribute is set
+if node['marathon']['options']['hostname'].nil?
+  if node.attribute?('ec2')
+    hostname = "--hostname #{node['ec2']['public_hostname']}"
+  else
+    hostname = "--hostname #{node['ipaddress']}"
+  end
 end
 
 command_line_options_array << hostname


### PR DESCRIPTION
If the 'hostname' attribute is set, the marathon cookbook will by default append another hostname (from ec2 or from the node's hostname). This change fixes that issue.
