### PR TITLE
only recommend zookeeper cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,4 +15,4 @@ end
   depends cb
 end
 
-depends 'zookeeper', '1.6.1'
+recommends 'zookeeper'


### PR DESCRIPTION
changed the dependency on zookeeper to a recommendation (as it is done in the `mesos_cookbook`)
