### PR TITLE
Allow marathon to use a different namespace from mesos.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,7 @@ default['marathon']['options']['zk_timeout']              = nil
 
 default['marathon']['zookeeper_server_list']              = []
 default['marathon']['zookeeper_port']                     = 2181
+default['marathon']['zookeeper_marathon_path']            = 'mesos'
 default['marathon']['zookeeper_path']                     = 'mesos'
 
 default['marathon']['zookeeper_exhibitor_discovery']      = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -89,6 +89,7 @@ if node['marathon']['zookeeper_server_list'].count > 0
   zk_server_list = node['marathon']['zookeeper_server_list']
   zk_port = node['marathon']['zookeeper_port']
   zk_path = node['marathon']['zookeeper_path']
+  zk_marathon_path = node['marathon']['zookeeper_marathon_path']
 end
 
 if node['marathon']['zookeeper_exhibitor_discovery'] && !node['marathon']['zookeeper_exhibitor_url'].nil?
@@ -111,7 +112,7 @@ end
 
 if zk_url_list.count > 0
   zk_master_option = "--master zk://#{zk_url_list.join(',')}/#{zk_path}"
-  zk_option = "--zk zk://#{zk_url_list.join(',')}/#{zk_path}"
+  zk_option = "--zk zk://#{zk_url_list.join(',')}/#{zk_marathon_path}"
 end
 
 # If we have been able to find zookeeper master endpoint and zookeeper hosts


### PR DESCRIPTION
Extremely useful if you have an absurd number of app definitions and keeps
things organized. There's no reason these two should be forced together.