### PR TITLE
Set permissions on the marathon tarball

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -22,6 +22,7 @@ pkg_location = ::File.join(Chef::Config[:file_cache_path], 'marathon.tgz')
 
 remote_file 'marathon-pkg' do
   path     pkg_location
+  mode     '0644'
   source   node['marathon']['source']['url']
   checksum node['marathon']['source']['checksum']
 end


### PR DESCRIPTION
If the system umask is stricter than the default (e.g. `077` rather than `027`) the file will not be accessible for later extraction by the marathon user. This commit explicitly sets the permissions on the tarball to be world readable.